### PR TITLE
Update space.rbl to use spaces, and not tabs

### DIFF
--- a/src/main/rbl/space.rbl
+++ b/src/main/rbl/space.rbl
@@ -15,9 +15,9 @@
 ;;; Deletes element at position i in Tuple
 (defOprn delete-i)
 (defPure Tuple (delete-i p)
-	(concat (prim-sub-object (self) 0 p)
-		(prim-sub-object (self) (fx+ p 1)
-				 (fx- (prim-size (self)) (fx+ p 1)))))
+    (concat (prim-sub-object (self) 0 p)
+        (prim-sub-object (self) (fx+ p 1)
+            (fx- (prim-size (self)) (fx+ p 1)))))
 
 (defOprn consume)
 (defOprn produce)


### PR DESCRIPTION
When pasting this into the rosette prompt, spaces are needed.